### PR TITLE
Calculate `sid` correctly.

### DIFF
--- a/Database/Memcache/Cluster.hs
+++ b/Database/Memcache/Cluster.hs
@@ -35,6 +35,7 @@ import Database.Memcache.Server
 import Database.Memcache.Types
 
 import Control.Concurrent (threadDelay)
+import Database.Memcache.Sid (splitIntRangeIntoNRangesSimple)
 import Control.Exception (handle, throwIO, SomeException)
 import Data.Default.Class
 import Data.Fixed (Milli)
@@ -139,8 +140,8 @@ getServers = cServers
 newCluster :: [ServerSpec] -> Options -> IO Cluster
 newCluster []    _ = throwIO $ ClientError NoServersReady
 newCluster hosts Options{..} = do
-    let numServers = length hosts
-    s <- mapM (\(serverIndex, ServerSpec{..}) -> newServer numServers serverIndex ssHost ssPort ssAuth) $ zip [0..] $ sort hosts
+    let numServers = fromInteger $ toInteger $ length hosts
+    s <- mapM (\(sid, ServerSpec{..}) -> newServer sid ssHost ssPort ssAuth) $ zip (splitIntRangeIntoNRangesSimple numServers) $ sort hosts
     return $
         Cluster {
             cServers   = (V.fromList $ sort s),

--- a/Database/Memcache/Server.hs
+++ b/Database/Memcache/Server.hs
@@ -73,12 +73,9 @@ instance Eq Server where
 instance Ord Server where
     compare x y = compare (sid x) (sid y)
 
-type NumServers = Int
-type ServerIndex = Int
-
 -- | Create a new Memcached server connection.
-newServer :: NumServers -> ServerIndex -> HostName -> ServiceName -> Authentication -> IO Server
-newServer numServers serverIndex host port auth = do
+newServer :: Int -> HostName -> ServiceName -> Authentication -> IO Server
+newServer sid host port auth = do
     fat <- newIORef 0
     pSock <- createPool connectSocket releaseSocket
                 sSTRIPES sKEEPALIVE sCONNECTIONS
@@ -91,14 +88,6 @@ newServer numServers serverIndex host port auth = do
         , failed   = fat
         }
   where
-    sid
-      | isLastServer = maxBound
-      | otherwise = segment
-
-    isLastServer = numServers == serverIndex + 1
-
-    segment = maxBound `div` numServers * (serverIndex + 1)
-
     connectSocket = do
         let hints = S.defaultHints {
           S.addrSocketType = S.Stream

--- a/Database/Memcache/Sid.hs
+++ b/Database/Memcache/Sid.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Database.Memcache.Sid (
+  splitIntRangeIntoNRanges,
+  splitIntRangeIntoNRangesSimple
+  ) where
+
+import Numeric.Natural (Natural)
+import Data.RangeSet.List (RSet)
+import qualified Data.RangeSet.List as RSet
+
+splitIntRangeIntoNRangesSimple :: Natural -> [Int]
+splitIntRangeIntoNRangesSimple n = RSet.findMax <$> splitIntoNRanges n (RSet.full @Int)
+
+-- Split the entirety of the 'Int' range into 'n' ranges of equal size.
+--
+-- When equal size is not possible, the last range in the result set will have less members than the others.
+--
+-- The maximum of each range can then be used as the `sid` for each server.
+--
+splitIntRangeIntoNRanges :: Natural -> [RSet Int]
+splitIntRangeIntoNRanges n = splitIntoNRanges n (RSet.full @Int)
+
+splitIntoNRanges :: Natural -> RSet Int -> [RSet Int]
+splitIntoNRanges numRanges initialRange = go numRanges initialRange
+  where go 0 _ = []
+        go 1 r = [r]
+        go n r = leftSubRange r : go (n - 1) (rightSubRange r)
+
+        rightSubRange r = RSet.singletonRange (fromInteger $ rightSubRangeMin r, maxBound @Int)
+        leftSubRange r = RSet.singletonRange (RSet.findMin r, fromInteger $ leftSubRangeMax r)
+
+        -- Use the 'Integer' type to avoid overflow. Do not let values that would overflow an 'Int' escape.
+        rightSubRangeMin r =
+          if succ (leftSubRangeMax r) >= globalMax
+              then globalMax
+              else succ (leftSubRangeMax r)
+
+        leftSubRangeMax r =
+          if leftRangeMax' >= globalMax
+              then globalMax
+              else leftRangeMax'
+          where leftRangeMax' = toInteger (RSet.findMin r) + subRangeSize
+        
+        -- These do not change in the recursive call of `go`.
+        subRangeSize = (globalMax - globalMin) `quot` toInteger numRanges
+        globalMin = toInteger $ minBound @Int
+        globalMax = toInteger $ maxBound @Int
+

--- a/memcache.cabal
+++ b/memcache.cabal
@@ -57,6 +57,7 @@ library
     Database.Memcache.Server
     Database.Memcache.Socket
     Database.Memcache.Types
+    Database.Memcache.Sid
   build-depends:
     base               <  5,
     binary             >= 0.6.2.0,
@@ -67,7 +68,8 @@ library
     network            >= 3.1.0.0,
     resource-pool      >= 0.2.1.0,
     vector             >= 0.7,
-    time               >= 1.4
+    time               >= 1.4,
+    range-set-list     >= 0.1.3.1
   default-language: Haskell2010
   other-extensions:
     BangPatterns,
@@ -78,27 +80,25 @@ library
     ScopedTypeVariables
   ghc-options: -Wall -fwarn-tabs
 
--- executable opgen
---   hs-source-dirs: tools
---   main-is: OpGen.hs
---   ghc-options: -threaded
---   build-depends:
---     async,
---     base < 5,
---     bytestring,
---     memcache,
---     network
---
--- executable load
---   hs-source-dirs: tools
---   main-is: Loader.hs
---   ghc-options: -threaded
---   build-depends:
---     async,
---     base < 5,
---     bytestring,
---     memcache,
---     network
+test-suite hspec
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Spec.hs
+  build-depends:
+    base           <  5,
+    binary         >= 0.6.2.0,
+    blaze-builder  >= 0.3.1.0,
+    bytestring     >= 0.9.2.1,
+    memcache,
+    hspec,
+    QuickCheck     >= 2.1.4.3,
+    network        >= 2.4,
+    range-set-list >= 0.1.3.1,
+    quickcheck-instances
+  other-modules:
+    MockServer
+  default-language: Haskell2010
+  ghc-options: -fwarn-tabs
 
 test-suite full
   type:           exitcode-stdio-1.0
@@ -133,4 +133,3 @@ benchmark parser
   other-extensions:
     OverloadedStrings
   ghc-options: -fwarn-tabs
-

--- a/test/Database/Memcache/SidSpec.hs
+++ b/test/Database/Memcache/SidSpec.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Database.Memcache.SidSpec (
+  spec
+  ) where
+
+import Test.Hspec
+import Test.QuickCheck
+import Database.Memcache.Sid (splitIntRangeIntoNRanges)
+import qualified Data.RangeSet.List as RSet
+import Test.QuickCheck.Instances.Natural ()
+
+spec :: Spec
+spec = 
+  describe "splitIntRangeIntoNRanges" $ do
+    it "works with 0" $ do
+      splitIntRangeIntoNRanges 0 `shouldBe` mempty
+
+    it "works with 1" $ do
+      splitIntRangeIntoNRanges 1 `shouldBe` [RSet.singletonRange (minBound, maxBound)]
+
+    it "returns list of 'n' length" $ property $
+      \n -> length (splitIntRangeIntoNRanges n) == fromIntegral n
+
+    it "covers the full Int range, modulo n == 0" $ property $ \case
+      0 -> True
+      n -> RSet.isFull $ mconcat $ splitIntRangeIntoNRanges n
+
+    it "first min is Int min, modulo n == 0" $ property $
+      \n ->
+        case splitIntRangeIntoNRanges n of
+          [] -> True
+          (x:_) -> RSet.findMin x == minBound
+
+    it "last max is Int max, modulo n == 0" $ property $
+      \n ->
+        case splitIntRangeIntoNRanges n of
+          [] -> True
+          xs -> RSet.findMax (last xs) == maxBound

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
The `sid` calculation is now more robust. It takes into account that an `Int`, which is what the `hash` function returns, can range into negative numbers.