### PR TITLE
tweak atomicity for elasticache autodiscover

### DIFF
--- a/Database/Memcache/ElastiCacheClient.hs
+++ b/Database/Memcache/ElastiCacheClient.hs
@@ -92,11 +92,11 @@ newClient options interval cfgEndpoint = bracket acquireCfgClient releaseCfgClie
 repeatAutoDiscover :: Options -> Int -> ConfigurationEndpoint -> MVar (V.Vector Server) -> IO ()
 repeatAutoDiscover opts interval cfgEndpoint mVar = do
   cfgClient <- Client.newClient [unConfigurationEndpoint cfgEndpoint] opts
-  forever $ modifyMVar_ mVar $ \_curServers -> do
+  forever $ do
     threadDelay interval
     serverSpecs <- resolveCluster cfgClient
     servers <- optsServerSpecsToServers opts serverSpecs
-    pure $ V.fromList $ sort servers
+    modifyMVar_ mVar $ \_curServers -> pure $ V.fromList $ sort servers
 
 resolveCluster :: Client -> IO [ServerSpec]
 resolveCluster cfgClient = do


### PR DESCRIPTION
we believe the way the code is otherwise will hold a lock for the entirety of `interval`, which is not optimal


FYI the base branch here is just a copy of whats on dteri main at time of writing. I made it like this for internal freckle discussion. If we like this, we should probably merge etc https://github.com/dterei/memcache-hs/pull/35